### PR TITLE
feat(context-dependencies): added context dependencies when `filePath` options is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webpack-mjml-plugin",
   "version": "1.1.0",
-  "description": "Webpack MJML Plugin for compiling MJML files.",
+  "description": "Webpack MJML plugin for compiling MJML files.",
   "main": "index.js",
   "scripts": {
     "build": "webpack --progress",

--- a/src/errors/no-source-files.js
+++ b/src/errors/no-source-files.js
@@ -4,7 +4,7 @@ module.exports = class NoSourceFilesWarning extends WebpackError {
   constructor(pattern, name) {
     super();
     this.name = 'NoSourceFilesWarning';
-    this.message = [name, `No source files match the patterns: '${pattern}'`].join('\n');
+    this.message = [name, `No source files match the pattern: '${pattern}'`].join('\n');
     Error.captureStackTrace(this, this.constructor);
   }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,14 +9,13 @@ module.exports = () => {
     entry: {},
     mode: 'development',
     output: {
-      path: join(__dirname, './dist'),
-      filename: 'js/[name].js'
+      path: join(__dirname, 'dist'),
+      clean: true
     },
     plugins: [
       new MJMLPlugin(join(SRC, 'templates'), {
-        extension: '.html',
         filePath: join(SRC, 'components'),
-        outputPath: resolve(__dirname, 'dist/')
+        outputPath: resolve(__dirname, 'dist')
       }),
       new CleanTerminalPlugin({ skipFirstRun: true })
     ],


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Added context dependencies when `filePath` options is set.

### Does this close any currently open issues?

None.

### Any other comments?

None.

### Checklist

Check all those that are applicable and complete. Put an `x` between the brackets (without spaces).

- [x] Merged with latest `master` branch
- [x] Travis CI passes (Linux support)
