### PR TITLE
chore: added a support for custom glob patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ module.exports = {
 
 In addition to the options available in the MJML documentation, there are 3 additional parameters described in the table below:
 
-| Parameter            |   Type   |     Default     | Description                                         |
-| -------------------- | :------: | :-------------: | --------------------------------------------------- |
-| `inputPath`          | `string` |   `undefined`   | The path where `.mjml` files are located.           |
-| `options.extensions` | `string` |     `.html`     | The default output extension.                       |
-| `options.outputPath` | `string` | `process.cwd()` | The path where compiled files should be written to. |
+| Parameter            |   Type   |     Default     | Description                                                                                                                                               |
+| -------------------- | :------: | :-------------: | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `inputPath`          | `string` |   `undefined`   | The path where `.mjml` files are located. The string supports [glob](https://github.com/isaacs/node-glob#glob-primer) syntax ex: `path/to/mjml/**/*.mjml` |
+| `options.extensions` | `string` |     `.html`     | The default output extension.                                                                                                                             |
+| `options.outputPath` | `string` | `process.cwd()` | The path where compiled files should be written to.                                                                                                       |
 
 ## Contributing :busts_in_silhouette:
 

--- a/src/webpack-mjml-store.js
+++ b/src/webpack-mjml-store.js
@@ -29,7 +29,7 @@ const WebpackMjmlStore = function (inputPath, options) {
 WebpackMjmlStore.prototype.apply = function (compiler) {
   const that = this;
   compiler.hooks.make.tapAsync(packageJSON.name, function (compilation, callback) {
-    glob(`${that.inputPath}/**/*.mjml`, async function (err, files) {
+    glob(`${that.inputPath}`, async function (err, files) {
       if (err) {
         throw err;
       }


### PR DESCRIPTION
BREAKING CHANGE: removed the default final glob patterns that included *.mjml.

### What does this implement/fix? Explain your changes.

#19 

### Does this close any currently open issues?

The issue `#19`

### Any other comments?

None

### Checklist

Check all those that are applicable and complete. Put an `x` between the brackets (without spaces).

- [x] Merged with latest `master` branch
- [x] Travis CI passes (Linux support)
