### PR TITLE
fix: output generation in subfolders

### DIFF
--- a/src/webpack-mjml-store.js
+++ b/src/webpack-mjml-store.js
@@ -5,7 +5,7 @@ const packageJSON = require('../package');
 const webpack = require('webpack');
 const { RawSource } = webpack.sources;
 const { NoSourceFilesWarning, BeautifyOptionDeprecated, MinifyOptionDeprecated, ErrorsMJMLParsing } = require('./errors/');
-const { basename } = require('path');
+const { basename, relative } = require('path');
 
 /**
  * @param {string} inputPath The path where `.mjml` files are located.
@@ -49,7 +49,7 @@ WebpackMjmlStore.prototype.apply = function (compiler) {
         compilation.fileDependencies.add(file);
 
         const data = await that.convertFile(file, outputFile);
-        compilation.emitAsset(basename(outputFile), new RawSource(data.response), {
+        compilation.emitAsset(relative(compilation.outputOptions.path, outputFile), new RawSource(data.response), {
           immutable: data.response === data.readable,
           javascriptModule: false
         });


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
If mjml output path is set to a subfolder of the compilation output path, two files are created. One in proper destination, but empty and second one with template content but at root of compilation output path.

This fix ensures that webpack compilation emits relative to it's output path so always only one file is created.

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete. Put an `x` between the brackets (without spaces).

- [x] Merged with latest `master` branch
- [x] GitHub CI passes (Linux support)
