### PR TITLE
:bug: read "response" from content object

### DIFF
--- a/src/webpack-mjml-store.js
+++ b/src/webpack-mjml-store.js
@@ -153,7 +153,7 @@ WebpackMjmlStore.prototype.ensureFileExists = function (file, contents) {
 WebpackMjmlStore.prototype.writeFile = function (file, contents) {
   return new Promise(function (resolve) {
     try {
-      fs.writeFile(file, contents, function (err) {
+      fs.writeFile(file, contents.response, function (err) {
         if (err) {
           throw err;
         }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Since Version 2.0.1 (or close to it), the function `convertFile` does no longer return a string, but an object. This causes the files to be created but stay unchanged. `writeFile` uses this object to write `contents` to a file. The returned object from `convertFile`, contains the actual content in the attribute `response` which is used in this fix as `contents.response` within `writeFile`.

### Does this close any currently open issues?

No.

### Any other comments?



### Checklist

Check all those that are applicable and complete. Put an `x` between the brackets (without spaces).

- [x] Merged with latest `master` branch
- [x] GitHub CI passes (Linux support)
