### PR TITLE
chore: normalized url for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/matteobertoldo/webpack-mjml-plugin.git"
+    "url": "git+https://github.com/matteobertoldo/webpack-mjml-plugin.git"
   },
   "keywords": [
     "webpack",


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

`npm` warning for git repo `url`

### Does this close any currently open issues?

None

### Any other comments?

None

### Checklist

Check all those that are applicable and complete. Put an `x` between the brackets (without spaces).

- [x] Merged with latest `master` branch
- [x] GitHub CI passes (Linux support)
